### PR TITLE
fix build error with PostgreSQL 10

### DIFF
--- a/src/ccache.c
+++ b/src/ccache.c
@@ -941,11 +941,12 @@ ccache_builder_connectdb(void)
 				elog(LOG, "ccache-builder%d: not assigned to a particular database", ccache_builder->builder_id);
 				startup_log = true;
 			}
-			ev = WaitLatch(MyLatch,
-						   WL_LATCH_SET |
-						   WL_TIMEOUT |
-						   WL_POSTMASTER_DEATH,
-						   60000L);
+			ev = StromWaitLatch(MyLatch,
+								WL_LATCH_SET |
+								WL_TIMEOUT |
+								WL_POSTMASTER_DEATH,
+								60000L,
+								PG_WAIT_EXTENSION);
 			if (ev & WL_POSTMASTER_DEATH)
 				elog(FATAL, "Unexpected postmaster dead");
 		}
@@ -1762,11 +1763,12 @@ ccache_builder_main(Datum arg)
 			ccache_builder->state = CCBUILDER_STATE__SLEEP;
 			SpinLockRelease(&ccache_state->lock);
 
-			ev = WaitLatch(MyLatch,
-						   WL_LATCH_SET |
-						   WL_TIMEOUT |
-						   WL_POSTMASTER_DEATH,
-						   timeout);
+			ev = StromWaitLatch(MyLatch,
+								WL_LATCH_SET |
+								WL_TIMEOUT |
+								WL_POSTMASTER_DEATH,
+								timeout,
+								PG_WAIT_EXTENSION);
 			if (ev & WL_POSTMASTER_DEATH)
 				elog(FATAL, "Unexpected postmaster dead");
 

--- a/src/gpu_mmgr.c
+++ b/src/gpu_mmgr.c
@@ -878,14 +878,11 @@ __gpuMemPreservedRequest(cl_int cuda_dindex,
 
 		PG_TRY();
 		{
-			ev = WaitLatch(MyLatch,
-						   WL_LATCH_SET |
-						   WL_TIMEOUT |
-						   WL_POSTMASTER_DEATH, 1000L
-#if PG_VERSION_NUM >= 100000
-						   ,PG_WAIT_EXTENSION
-#endif
-);
+			ev = StromWaitLatch(MyLatch,
+								WL_LATCH_SET |
+								WL_TIMEOUT |
+								WL_POSTMASTER_DEATH, 1000L,
+								PG_WAIT_EXTENSION);
 			ResetLatch(MyLatch);
 			if (ev & WL_POSTMASTER_DEATH)
 				elog(FATAL, "unexpected postmaster dead");
@@ -1190,14 +1187,11 @@ gpummgrBgWorkerMain(Datum arg)
 
 			SpinLockRelease(&gmemp_head->lock);
 
-			ev = WaitLatch(MyLatch,
-						   WL_LATCH_SET |
-						   WL_TIMEOUT |
-						   WL_POSTMASTER_DEATH, 5000L
-#if PG_VERSION_NUM >= 100000
-						   ,PG_WAIT_EXTENSION
-#endif
-				);
+			ev = StromWaitLatch(MyLatch,
+								WL_LATCH_SET |
+								WL_TIMEOUT |
+								WL_POSTMASTER_DEATH, 5000L,
+								PG_WAIT_EXTENSION);
 			ResetLatch(MyLatch);
 			if (ev & WL_POSTMASTER_DEATH)
 				elog(FATAL, "unexpected Postmaster dead");

--- a/src/gpu_tasks.c
+++ b/src/gpu_tasks.c
@@ -329,15 +329,12 @@ fetch_next_gputask(GpuTaskState *gts)
 			 */
 			pthreadMutexUnlock(gcontext->mutex);
 
-			ev = WaitLatch(MyLatch,
-						   WL_LATCH_SET |
-						   WL_TIMEOUT |
-						   WL_POSTMASTER_DEATH,
-						   500L
-#if PG_VERSION_NUM >= 100000
-						   ,PG_WAIT_EXTENSION
-#endif
-				);
+			ev = StromWaitLatch(MyLatch,
+								WL_LATCH_SET |
+								WL_TIMEOUT |
+								WL_POSTMASTER_DEATH,
+								500L,
+								PG_WAIT_EXTENSION);
 			if (ev & WL_POSTMASTER_DEATH)
 				ereport(FATAL,
 						(errcode(ERRCODE_ADMIN_SHUTDOWN),
@@ -409,15 +406,12 @@ retry:
 
 		CHECK_FOR_GPUCONTEXT(gcontext);
 
-		ev = WaitLatch(MyLatch,
-					   WL_LATCH_SET |
-					   WL_TIMEOUT |
-					   WL_POSTMASTER_DEATH,
-					   500L
-#if PG_VERSION_NUM >= 100000
-					   ,PG_WAIT_EXTENSION
-#endif
-			);
+		ev = StromWaitLatch(MyLatch,
+							WL_LATCH_SET |
+							WL_TIMEOUT |
+							WL_POSTMASTER_DEATH,
+							500L,
+							PG_WAIT_EXTENSION);
 		if (ev & WL_POSTMASTER_DEATH)
 			ereport(FATAL,
 					(errcode(ERRCODE_ADMIN_SHUTDOWN),

--- a/src/gpujoin.c
+++ b/src/gpujoin.c
@@ -3730,15 +3730,12 @@ gpujoinSyncRightOuterJoin(GpuTaskState *gts)
 
 			CHECK_FOR_GPUCONTEXT(gcontext);
 
-			ev = WaitLatch(MyLatch,
-						   WL_LATCH_SET |
-						   WL_TIMEOUT |
-						   WL_POSTMASTER_DEATH,
-						   1000L
-#if PG_VERSION_NUM >= 100000
-						   ,PG_WAIT_EXTENSION
-#endif
-				);
+			ev = StromWaitLatch(MyLatch,
+								WL_LATCH_SET |
+								WL_TIMEOUT |
+								WL_POSTMASTER_DEATH,
+								1000L,
+								PG_WAIT_EXTENSION);
 			if (ev & WL_POSTMASTER_DEATH)
 				elog(FATAL, "Unexpected Postmaster Dead");
 			ResetLatch(MyLatch);
@@ -5458,13 +5455,10 @@ GpuJoinInnerPreload(GpuTaskState *gts, CUdeviceptr *p_m_kmrels)
 			/* wait for the completion of inner preload by the master */
 			CHECK_FOR_INTERRUPTS();
 
-			WaitLatch(&MyProc->procLatch,
-					  WL_LATCH_SET,
-					  -1
-#if PG_VERSION_NUM >= 100000
-					  ,PG_WAIT_EXTENSION
-#endif
-				);
+			StromWaitLatch(&MyProc->procLatch,
+						   WL_LATCH_SET,
+						   -1,
+						   PG_WAIT_EXTENSION);
 			ResetLatch(&MyProc->procLatch);
 		}
 	}

--- a/src/pg_strom.h
+++ b/src/pg_strom.h
@@ -192,6 +192,14 @@
 #endif
 #include "cuda_common.h"
 
+#if PG_VERSION_NUM >= 100000
+#define StromWaitLatch(latch, wakeEvents, timeout, wait_event_info)     \
+	WaitLatch((latch), (wakeEvents), (timeout), (wait_event_info))
+#else
+#define StromWaitLatch(latch, wakeEvents, timeout, wait_event_info)     \
+	WaitLatch((latch), (wakeEvents), (timeout))
+#endif
+
 #define PGSTROM_SCHEMA_NAME		"pgstrom"
 
 #define RESTRACK_HASHSIZE		53


### PR DESCRIPTION
Message:

    src/ccache.c: In function 'ccache_builder_connectdb':
    src/ccache.c:944:9: error: too few arguments to function 'WaitLatch'
        ev = WaitLatch(MyLatch,
             ^~~~~~~~~
    In file included from /tmp/local/include/postgresql/server/storage/proc.h:19:0,
                     from /tmp/local/include/postgresql/server/storage/shm_mq.h:18,
                     from /tmp/local/include/postgresql/server/access/parallel.h:20,
                     from /tmp/local/include/postgresql/server/executor/nodeCustom.h:15,
                     from src/pg_strom.h:55,
                     from src/ccache.c:18:
    /tmp/local/include/postgresql/server/storage/latch.h:174:12: note: declared here
     extern int WaitLatch(volatile Latch *latch, int wakeEvents, long timeout,
                ^~~~~~~~~
    src/ccache.c: In function 'ccache_builder_main':
    src/ccache.c:1765:9: error: too few arguments to function 'WaitLatch'
        ev = WaitLatch(MyLatch,
             ^~~~~~~~~
    In file included from /tmp/local/include/postgresql/server/storage/proc.h:19:0,
                     from /tmp/local/include/postgresql/server/storage/shm_mq.h:18,
                     from /tmp/local/include/postgresql/server/access/parallel.h:20,
                     from /tmp/local/include/postgresql/server/executor/nodeCustom.h:15,
                     from src/pg_strom.h:55,
                     from src/ccache.c:18:
    /tmp/local/include/postgresql/server/storage/latch.h:174:12: note: declared here
     extern int WaitLatch(volatile Latch *latch, int wakeEvents, long timeout,
                ^~~~~~~~~
    src/ccache.c: In function 'guc_check_ccache_databases':
    src/ccache.c:1795:7: warning: implicit declaration of function 'SplitIdentifierString' [-Wimplicit-function-declaration]
      if (!SplitIdentifierString(rawnames, ',', &options))
           ^~~~~~~~~~~~~~~~~~~~~
    At top level:
    src/ccache.c:254:1: warning: 'ccache_put_chunk' defined but not used [-Wunused-function]
     ccache_put_chunk(ccacheChunk *cc_chunk)
     ^~~~~~~~~~~~~~~~
    src/ccache.c:196:1: warning: 'ccache_get_chunk' defined but not used [-Wunused-function]
     ccache_get_chunk(Oid table_oid, BlockNumber block_nr)
     ^~~~~~~~~~~~~~~~
    <builtin>: recipe for target 'src/ccache.o' failed
    make: *** [src/ccache.o] Error 1


PostgreSQL 10 changes `WaitLatch()` signature. All files except `src/ccache.c` are already cared but only `src/ccache.c` supports only old signature.

I think that introducing a wrapper macro (`StromWaitLatch()`) simplifies `*.c` files but you may prefer to use `#if PG_VERSION_NUM >= 100000` in `src/ccache.c`.
