### PR TITLE
fix indent

### DIFF
--- a/src/gpu_mmgr.c
+++ b/src/gpu_mmgr.c
@@ -358,8 +358,8 @@ __gpuMemAllocManagedRaw(GpuContext *gcontext,
 	CUresult	rc;
 
 	rc = cuCtxPushCurrent(gcontext->cuda_context);
-    if (rc != CUDA_SUCCESS)
-        return rc;
+	if (rc != CUDA_SUCCESS)
+		return rc;
 
 	rc = cuMemAllocManaged(&m_deviceptr, bytesize, flags);
 	if (rc != CUDA_SUCCESS)


### PR DESCRIPTION
`gcc (Debian 7.2.0-17) 7.2.1 20171205` says the following warning:

    src/gpu_mmgr.c: In function '__gpuMemAllocManagedRaw':
    src/gpu_mmgr.c:361:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
         if (rc != CUDA_SUCCESS)
         ^~
    src/gpu_mmgr.c:364:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
      rc = cuMemAllocManaged(&m_deviceptr, bytesize, flags);
      ^~