### PR TITLE
fix attnum in build_device_projection()

### DIFF
--- a/src/gpuscan.c
+++ b/src/gpuscan.c
@@ -1501,6 +1501,7 @@ build_device_projection(Index scanrelid,
 	 * tlist_old has smaller number of attributes than base relation's
 	 * definition.
 	 */
+	attnum--;
 	if (attnum != tupdesc->natts)
 		tlist_compatible = false;
 


### PR DESCRIPTION
I think `attnum` should decrease by 1 when reaching the end of the `for` loop, since `attnum` should be equal to the length of `tlist_old`.