### PR TITLE
fix compilation error for PG 9.6, which does not support table partitioning

### DIFF
--- a/src/gpupreagg.c
+++ b/src/gpupreagg.c
@@ -1438,6 +1438,7 @@ try_add_final_aggregation_paths(PlannerInfo *root,
 	}
 }
 
+#if PG_VERSION_NUM >= 100000
 /*
  * try_add_gpupreagg_append_paths
  */
@@ -1536,6 +1537,7 @@ try_add_gpupreagg_append_paths(PlannerInfo *root,
 									num_groups,
 									agg_final_costs);
 }
+#endif
 
 /*
  * try_add_gpupreagg_paths
@@ -1611,6 +1613,7 @@ try_add_gpupreagg_paths(PlannerInfo *root,
 	if (agg_final_costs.numOrderedAggs > 0)
 		return;
 
+#if PG_VERSION_NUM >= 100000
 	if (enable_partitionwise_gpupreagg)
 		try_add_gpupreagg_append_paths(root,
 									   group_rel,
@@ -1624,6 +1627,7 @@ try_add_gpupreagg_paths(PlannerInfo *root,
 									   &agg_final_costs,
 									   can_pullup_outerscan,
 									   try_parallel_path);
+#endif
 
 	partial_path = prepend_gpupreagg_path(root,
 										  group_rel,


### PR DESCRIPTION
Code can be compiled on PG 9.6 now. Hope the fix is right and complete :-)