### PR TITLE
fix: pg11 do not have is_dummy_rel

### DIFF
--- a/src/gpujoin.c
+++ b/src/gpujoin.c
@@ -1570,7 +1570,7 @@ __try_partitionwise_gpujoin(PlannerInfo *root,
 	switch (child_sjinfo->jointype)
 	{
 		case JOIN_INNER:
-			if (is_dummy_rel(outer_rel) || is_dummy_rel(inner_rel) ||
+			if (IS_DUMMY_REL(outer_rel) || IS_DUMMY_REL(inner_rel) ||
 				restriction_is_constant_false(child_restrictlist,
 											  child_join_rel, false))
 			{
@@ -1586,7 +1586,7 @@ __try_partitionwise_gpujoin(PlannerInfo *root,
 			break;
 		case JOIN_LEFT:
 			Assert(!reverse);
-			if (is_dummy_rel(outer_rel) ||
+			if (IS_DUMMY_REL(outer_rel) ||
 				restriction_is_constant_false(child_restrictlist,
 											  child_join_rel, true))
 			{


### PR DESCRIPTION
Hi, I've got `undefined symbol: is_dummy_rel` while compile and run with postgres 11.2 and then postgres shutdown.

It seems that is_dummy_rel came from postgres 12 and have not backported to postgres 11.

[Related commit of postgres](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;f=src/include/nodes/pathnodes.h;h=1d338584062b3e53b738f987ecb0d2b67745232a)
