### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ include $(STROM_BUILD_ROOT)/Makefile.cuda
 #
 # PG-Strom version
 #
-PGSTROM_VERSION := 3.3
+PGSTROM_VERSION := 3.4
 PGSTROM_RELEASE := devel
 
 #


### PR DESCRIPTION
Update the PGSTROM_VERSION 3.3 to 3.4 of Makefile.

このプルリクエストは軽微なbugを修正するためのものです。

```
● postgresql-15.service - PostgreSQL 15 database server
   Loaded: loaded (/usr/lib/systemd/system/postgresql-15.service; disabled; vendor preset: disabled)
...
12月 06 16:23:03 pgstrom-demo1.localdomain systemd[1]: Starting PostgreSQL 15 database server...
12月 06 16:23:03 pgstrom-demo1.localdomain postmaster[3160]: 2022-12-06 16:23:03.701 JST [3160] LOG:  NVRTC 11.8 is successfully loaded.
12月 06 16:23:03 pgstrom-demo1.localdomain postmaster[3160]: 2022-12-06 16:23:03.701 JST [3160] LOG:  HeteroDB Extra module is not available
12月 06 16:23:03 pgstrom-demo1.localdomain postmaster[3160]: 2022-12-06 16:23:03.701 JST [3160] LOG:  PG-Strom version 3.3 built for PostgreSQL 15
```

修正後

```
12月 06 17:07:38 pgstrom-demo1.localdomain postmaster[4832]: 2022-12-06 17:07:38.966 JST [4832] LOG:  PG-Strom version 3.4 built for PostgreSQL 15
```

`make rpm`で、PG-Strom 3.4としてパッケージが作成できます。

```
# make rpm
...
書き込み完了: /root/rpmbuild/SRPMS/pg_strom-PG15-3.4-devel.el8.src.rpm
書き込み完了: /root/rpmbuild/RPMS/x86_64/pg_strom-PG15-3.4-devel.el8.x86_64.rpm
書き込み完了: /root/rpmbuild/RPMS/x86_64/pg_strom-PG15-debuginfo-3.4-devel.el8.x86_64.rpm
```