### PR TITLE
[bug fix] fix dead loop in `gpuCacheAutoPreloadConnectDatabase`

### DIFF
--- a/src/gpu_cache.c
+++ b/src/gpu_cache.c
@@ -4219,7 +4219,8 @@ gpuCacheStartupPreloader(Datum arg)
 
 		rel = table_openrv(&rvar, AccessShareLock);
 		gc_desc = lookupGpuCacheDesc(rel);
-		initialLoadGpuCache(gc_desc, rel);
+		if (gc_desc)
+			initialLoadGpuCache(gc_desc, rel);
 		table_close(rel, NoLock);
 
 		elog(LOG, "gpucache: auto preload '%s.%s' (DB: %s)",

--- a/src/gpu_cache.c
+++ b/src/gpu_cache.c
@@ -4177,6 +4177,7 @@ gpuCacheAutoPreloadConnectDatabase(int32 *p_start, int32 *p_end)
 
 		if (strcmp(database_name, entry->database_name) != 0)
 			break;
+		curr++;
 	}
 	gcache_shared_head->gcache_auto_preload_count = curr;
 


### PR DESCRIPTION
Bug fix:
- Fix null pointer reference in `gpuCacheStartupPreloader()`
- Fix dead loop in `gpuCacheAutoPreloadConnectDatabase()`