### PR TITLE
[bugfix] Fix the bug of dynamically allocating fallback buffer size a…

### DIFF
--- a/src/relscan.c
+++ b/src/relscan.c
@@ -388,13 +388,13 @@ pgstromStoreFallbackTuple(pgstromTaskState *pts, HeapTuple htuple)
 	sz = MAXALIGN(offsetof(kern_tupitem, htup) + htuple->t_len);
 	while (pts->fallback_usage + sz > pts->fallback_bufsz)
 	{
-		pts->fallback_bufsz *= 2 + BLCKSZ;
+		pts->fallback_bufsz = pts->fallback_bufsz * 2 + BLCKSZ;
 		pts->fallback_buffer = repalloc_huge(pts->fallback_buffer,
 											 pts->fallback_bufsz);
 	}
 	while (pts->fallback_nitems >= pts->fallback_nrooms)
 	{
-		pts->fallback_nrooms *= 2 + 100;
+		pts->fallback_nrooms = pts->fallback_nrooms * 2 + 100;
 		pts->fallback_tuples = repalloc_huge(pts->fallback_tuples,
 											 sizeof(off_t) * pts->fallback_nrooms);
 	}


### PR DESCRIPTION
…nd nrooms

The following two lines of code seem to be a typo. Based on experience, `fallback_bufsz` and `fallback_nrooms` should be multiplied by 2 first and then a constant is added, instead of multiplying by (2 + BLCKSZ) or (2 + 100). Otherwise, it will cause the growth rate of fallback_bufsz
 and fallback_nrooms to be too fast, leading to an OOM issue.
```c
	while (pts->fallback_usage + sz > pts->fallback_bufsz)
	{
		pts->fallback_bufsz *= 2 + BLCKSZ;
		...
	}
	while (pts->fallback_nitems >= pts->fallback_nrooms)
	{
		pts->fallback_nrooms *= 2 + 100;
		...
	}
```