### PR TITLE
Fix/fluentd open system call

### DIFF
--- a/fluentd/arrow_ruby.cpp
+++ b/fluentd/arrow_ruby.cpp
@@ -1033,7 +1033,7 @@ arrowFileWrite::OpenFile(std::string &filename)
 			filename += temp;
 		}
 		/* open the output file */
-		fdesc = open(filename.c_str(), O_RDWR | O_CREAT | O_EXCL | 0600);
+		fdesc = open(filename.c_str(), O_RDWR | O_CREAT | O_EXCL, 0600);
 		if (fdesc < 0 && errno != EEXIST)
 			Elog("failed on open('%s'): %m", filename.c_str());
 	}


### PR DESCRIPTION
openの指定の問題で、ビルドが失敗するため修正。

```
/usr/include/bits/fcntl2.h:50:31: error: call to ‘__open_missing_mode’ declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
   50 |           __open_missing_mode ();
      |           ~~~~~~~~~~~~~~~~~~~~^~
gmake[1]: *** [Makefile:243: arrow_ruby.o] Error 1
gmake[1]: Leaving directory '/home/onishi/pg-strom/fluentd/tmp/x86_64-linux/arrow_file_write/3.4.7'
```