### PR TITLE
Fix a minor error about to the formatting of relid

### DIFF
--- a/src/gpu_join.c
+++ b/src/gpu_join.c
@@ -1860,7 +1860,7 @@ build_explain_tlist_junks(codegen_context *context,
 			}
 		}
 		if (lc == NULL)
-			elog(INFO, "scan_relid=%d anum=%d tlist_dev=%s", pp_info->scan_relid, anum, nodeToString(context->tlist_dev));
+			elog(INFO, "scan_relid=%u anum=%d tlist_dev=%s", pp_info->scan_relid, anum, nodeToString(context->tlist_dev));
 		Assert(lc != NULL);
 	}
 #endif


### PR DESCRIPTION
The Index is unsigned int in PostgreSQL.
When Index is greater than or equal to 2^31, if it is formatted with %d, the output will be negative.