### PR TITLE
PG19対応: VARSIZE/VARDATA系マクロにDatumを渡す箇所をDatumGetPointer()でラップ

### DIFF
--- a/src/arrow_fdw.c
+++ b/src/arrow_fdw.c
@@ -990,12 +990,12 @@ __assignArrowStatsBinaryOne(MinMaxStatDatum *stats,
 													CStringGetDatum(__max_token),
 													ObjectIdGetDatum(InvalidOid),
 													Int32GetDatum(-1));
-				if (VARSIZE(__min) <= sizeof(NumericData) &&
-					VARSIZE(__max) <= sizeof(NumericData))
+				if (VARSIZE(DatumGetPointer(__min)) <= sizeof(NumericData) &&
+					VARSIZE(DatumGetPointer(__max)) <= sizeof(NumericData))
 				{
 					stats->isnull = false;
-					memcpy(&stats->min.numeric, DatumGetPointer(__min), VARSIZE(__min));
-					memcpy(&stats->max.numeric, DatumGetPointer(__max), VARSIZE(__max));
+					memcpy(&stats->min.numeric, DatumGetPointer(__min), VARSIZE(DatumGetPointer(__min)));
+					memcpy(&stats->max.numeric, DatumGetPointer(__max), VARSIZE(DatumGetPointer(__max)));
 				}
 				else
 				{
@@ -3885,7 +3885,7 @@ __arrowKdsAssignVirtualColumns(kern_data_store *kds,
 		{
 			appendBinaryLargeStringInfo(chunk_buffer,
 										DatumGetPointer(virtual_datum),
-										VARSIZE_ANY(virtual_datum));
+										VARSIZE_ANY(DatumGetPointer(virtual_datum)));
 		}
 		else
 		{
@@ -4858,7 +4858,7 @@ pg_array_arrow_ref(kern_data_store *kds,
 		}
 		else if (smeta->attlen == -1)
 		{
-			int32_t		vl_len = VARSIZE(datum);
+			int32_t		vl_len = VARSIZE(DatumGetPointer(datum));
 
 			if (nullmap)
 				nullmap[i>>3] |= (1<<(i&7));

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -628,7 +628,7 @@ devtype_bytea_hash(bool isnull, Datum value)
 {
 	if (isnull)
 		return 0;
-	return hash_any((unsigned char *)VARDATA_ANY(value), VARSIZE_ANY_EXHDR(value));
+	return hash_any((unsigned char *)VARDATA_ANY(DatumGetPointer(value)), VARSIZE_ANY_EXHDR(DatumGetPointer(value)));
 }
 
 static uint32_t
@@ -636,7 +636,7 @@ devtype_text_hash(bool isnull, Datum value)
 {
 	if (isnull)
 		return 0;
-	return hash_any((unsigned char *)VARDATA_ANY(value), VARSIZE_ANY_EXHDR(value));
+	return hash_any((unsigned char *)VARDATA_ANY(DatumGetPointer(value)), VARSIZE_ANY_EXHDR(DatumGetPointer(value)));
 }
 
 static uint32_t
@@ -644,8 +644,8 @@ devtype_bpchar_hash(bool isnull, Datum value)
 {
 	if (!isnull)
 	{
-		char   *s = VARDATA_ANY(value);
-		int		sz = VARSIZE_ANY_EXHDR(value);
+		char   *s = VARDATA_ANY(DatumGetPointer(value));
+		int		sz = VARSIZE_ANY_EXHDR(DatumGetPointer(value));
 
 		sz = bpchartruelen(s, sz);
 		return hash_any((unsigned char *)s, sz);
@@ -826,7 +826,7 @@ devtype_jsonb_hash(bool isnull, Datum value)
 {
 	if (!isnull)
 	{
-		JsonbContainer *jc = (JsonbContainer *) VARDATA_ANY(value);
+		JsonbContainer *jc = (JsonbContainer *) VARDATA_ANY(DatumGetPointer(value));
 
 		return __devtype_jsonb_hash(jc);
 	}
@@ -852,7 +852,7 @@ devtype_cube_hash(bool isnull, Datum value)
 {
 	if (isnull)
 		return 0;
-	return hash_any((unsigned char *)VARDATA_ANY(value), VARSIZE_ANY_EXHDR(value));
+	return hash_any((unsigned char *)VARDATA_ANY(DatumGetPointer(value)), VARSIZE_ANY_EXHDR(DatumGetPointer(value)));
 }
 
 /*
@@ -1691,7 +1691,7 @@ codegen_const_expression(codegen_context *context,
 			else if (con->constlen == -1)
 				appendBinaryStringInfo(buf,
 									   DatumGetPointer(con->constvalue),
-									   VARSIZE_ANY(con->constvalue));
+									   VARSIZE_ANY(DatumGetPointer(con->constvalue)));
 			else
 				elog(ERROR, "unsupported type length: %d", con->constlen);
 		}
@@ -2577,7 +2577,7 @@ try_casewhen_expression_by_hashed_array(codegen_context *context,
 				else
 					appendBinaryStringInfo(&temp,
 										   DatumGetPointer(e_con->constvalue),
-										   VARSIZE_ANY(e_con->constvalue));
+										   VARSIZE_ANY(DatumGetPointer(e_con->constvalue)));
 			}
 			/* result */
 			if (!r_con->constisnull)
@@ -2594,7 +2594,7 @@ try_casewhen_expression_by_hashed_array(codegen_context *context,
 				else
 					appendBinaryStringInfo(&temp,
 										   DatumGetPointer(r_con->constvalue),
-										   VARSIZE_ANY(r_con->constvalue));
+										   VARSIZE_ANY(DatumGetPointer(r_con->constvalue)));
 			}
 		}
 		/* default value, if any */
@@ -2612,7 +2612,7 @@ try_casewhen_expression_by_hashed_array(codegen_context *context,
 				else
 					offset = __appendBinaryStringInfo(&temp,
 													  DatumGetPointer(d_con->constvalue),
-													  VARSIZE_ANY(d_con->constvalue));
+													  VARSIZE_ANY(DatumGetPointer(d_con->constvalue)));
 			}
 			kexp->u.haop.default_offset = offset;
 		}
@@ -2859,7 +2859,7 @@ __build_hashed_array_op_expression(codegen_context *context,
 				if (dtype_e->type_byval)
 					appendBinaryStringInfo(&temp, &datum, dtype_e->type_length);
 				else
-					appendBinaryStringInfo(&temp, DatumGetPointer(datum), VARSIZE_ANY(datum));
+					appendBinaryStringInfo(&temp, DatumGetPointer(datum), VARSIZE_ANY(DatumGetPointer(datum)));
 			}
 			/* value (bool has character alignment) */
 			appendStringInfoChar(&temp, true);

--- a/src/executor.c
+++ b/src/executor.c
@@ -737,8 +737,8 @@ pgstromBuildSessionInfo(pgstromTaskState *pts,
 
 		Assert((pp_info->xpu_task_flags & DEVTASK__SELECT_INTO_DIRECT) != 0);
 		session->select_into_pathname =
-			__appendBinaryStringInfo(&buf, VARDATA_ANY(pathname),
-									 VARSIZE_ANY_EXHDR(pathname));
+			__appendBinaryStringInfo(&buf, VARDATA_ANY(DatumGetPointer(pathname)),
+									 VARSIZE_ANY_EXHDR(DatumGetPointer(pathname)));
 		appendStringInfoChar(&buf, '\0');
 
 		/* length and block_offset must be set on allocation time */


### PR DESCRIPTION
PostgreSQL 19でVARSIZE/VARSIZE_ANY/VARSIZE_ANY_EXHDR/VARDATA/VARDATA_ANYが、 単純なマクロから`const void *`を引数に取るstatic inline関数に変更された。 そのため、Datum型の値をそのまま渡していた箇所がコンパイルエラーとなる
(整数からポインタへの暗黙変換をGCC 14がデフォルトでエラー扱いするため)。

該当18箇所(arrow_fdw.c/codegen.c/executor.c)をDatumGetPointer()でラップし、 既に同じDatumを別引数でDatumGetPointer()経由で渡している箇所との書き方を統一した。