### PR TITLE
PostgreSQL 19のビルド互換性に対応

### DIFF
--- a/src/arrow_fdw.c
+++ b/src/arrow_fdw.c
@@ -2021,7 +2021,7 @@ __arrowFieldTypeToPGType(const ArrowField *field,
 	ArrowTypeOptions attopts;
 
 	memset(&attopts, 0, sizeof(ArrowTypeOptions));
-	attopts.align = ALIGNOF_LONG;	/* some data types expand the alignment */
+	attopts.align = MAXIMUM_ALIGNOF;	/* some data types expand the alignment */
 	switch (t->node.tag)
 	{
 		case ArrowNodeTag__Int:
@@ -7035,8 +7035,6 @@ pgstrom_init_arrow_fdw(void)
 	shmem_startup_next = shmem_startup_hook;
 	shmem_startup_hook = pgstrom_startup_arrow_fdw;
 }
-
-
 
 
 

--- a/src/arrow_fdw.c
+++ b/src/arrow_fdw.c
@@ -4794,7 +4794,7 @@ pg_array_arrow_ref(kern_data_store *kds,
 	ArrayType  *res;
 	size_t		sz;
 	uint32_t	i, nitems = end - start;
-	bits8	   *nullmap = NULL;
+	uint8	   *nullmap = NULL;
 	size_t		usage, __usage;
 
 	/* sanity checks */
@@ -7035,7 +7035,6 @@ pgstrom_init_arrow_fdw(void)
 	shmem_startup_next = shmem_startup_hook;
 	shmem_startup_hook = pgstrom_startup_arrow_fdw;
 }
-
 
 
 

--- a/src/arrow_fdw.c
+++ b/src/arrow_fdw.c
@@ -6916,7 +6916,8 @@ pgstrom_startup_arrow_fdw(void)
 	Assert(!found);
 
 	memset(arrow_metadata_cache, 0, sizeof(arrowMetadataCacheHead));
-	LWLockInitialize(&arrow_metadata_cache->mutex, LWLockNewTrancheId());
+	LWLockInitialize(&arrow_metadata_cache->mutex,
+					 pgstrom_new_lwlock_tranche("arrowMetadataCache"));
 	SpinLockInit(&arrow_metadata_cache->lru_lock);
 	dlist_init(&arrow_metadata_cache->lru_list);
 	dlist_init(&arrow_metadata_cache->free_blocks);
@@ -7035,7 +7036,6 @@ pgstrom_init_arrow_fdw(void)
 	shmem_startup_next = shmem_startup_hook;
 	shmem_startup_hook = pgstrom_startup_arrow_fdw;
 }
-
 
 
 

--- a/src/arrow_fdw.c
+++ b/src/arrow_fdw.c
@@ -990,12 +990,12 @@ __assignArrowStatsBinaryOne(MinMaxStatDatum *stats,
 													CStringGetDatum(__max_token),
 													ObjectIdGetDatum(InvalidOid),
 													Int32GetDatum(-1));
-				if (VARSIZE(__min) <= sizeof(NumericData) &&
-					VARSIZE(__max) <= sizeof(NumericData))
+				if (VARSIZE(DatumGetPointer(__min)) <= sizeof(NumericData) &&
+					VARSIZE(DatumGetPointer(__max)) <= sizeof(NumericData))
 				{
 					stats->isnull = false;
-					memcpy(&stats->min.numeric, DatumGetPointer(__min), VARSIZE(__min));
-					memcpy(&stats->max.numeric, DatumGetPointer(__max), VARSIZE(__max));
+					memcpy(&stats->min.numeric, DatumGetPointer(__min), VARSIZE(DatumGetPointer(__min)));
+					memcpy(&stats->max.numeric, DatumGetPointer(__max), VARSIZE(DatumGetPointer(__max)));
 				}
 				else
 				{
@@ -3885,7 +3885,7 @@ __arrowKdsAssignVirtualColumns(kern_data_store *kds,
 		{
 			appendBinaryLargeStringInfo(chunk_buffer,
 										DatumGetPointer(virtual_datum),
-										VARSIZE_ANY(virtual_datum));
+										VARSIZE_ANY(DatumGetPointer(virtual_datum)));
 		}
 		else
 		{
@@ -4858,7 +4858,7 @@ pg_array_arrow_ref(kern_data_store *kds,
 		}
 		else if (smeta->attlen == -1)
 		{
-			int32_t		vl_len = VARSIZE(datum);
+			int32_t		vl_len = VARSIZE(DatumGetPointer(datum));
 
 			if (nullmap)
 				nullmap[i>>3] |= (1<<(i&7));

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -628,7 +628,7 @@ devtype_bytea_hash(bool isnull, Datum value)
 {
 	if (isnull)
 		return 0;
-	return hash_any((unsigned char *)VARDATA_ANY(value), VARSIZE_ANY_EXHDR(value));
+	return hash_any((unsigned char *)VARDATA_ANY(DatumGetPointer(value)), VARSIZE_ANY_EXHDR(DatumGetPointer(value)));
 }
 
 static uint32_t
@@ -636,7 +636,7 @@ devtype_text_hash(bool isnull, Datum value)
 {
 	if (isnull)
 		return 0;
-	return hash_any((unsigned char *)VARDATA_ANY(value), VARSIZE_ANY_EXHDR(value));
+	return hash_any((unsigned char *)VARDATA_ANY(DatumGetPointer(value)), VARSIZE_ANY_EXHDR(DatumGetPointer(value)));
 }
 
 static uint32_t
@@ -644,8 +644,8 @@ devtype_bpchar_hash(bool isnull, Datum value)
 {
 	if (!isnull)
 	{
-		char   *s = VARDATA_ANY(value);
-		int		sz = VARSIZE_ANY_EXHDR(value);
+		char   *s = VARDATA_ANY(DatumGetPointer(value));
+		int		sz = VARSIZE_ANY_EXHDR(DatumGetPointer(value));
 
 		sz = bpchartruelen(s, sz);
 		return hash_any((unsigned char *)s, sz);
@@ -826,7 +826,7 @@ devtype_jsonb_hash(bool isnull, Datum value)
 {
 	if (!isnull)
 	{
-		JsonbContainer *jc = (JsonbContainer *) VARDATA_ANY(value);
+		JsonbContainer *jc = (JsonbContainer *) VARDATA_ANY(DatumGetPointer(value));
 
 		return __devtype_jsonb_hash(jc);
 	}
@@ -852,7 +852,7 @@ devtype_cube_hash(bool isnull, Datum value)
 {
 	if (isnull)
 		return 0;
-	return hash_any((unsigned char *)VARDATA_ANY(value), VARSIZE_ANY_EXHDR(value));
+	return hash_any((unsigned char *)VARDATA_ANY(DatumGetPointer(value)), VARSIZE_ANY_EXHDR(DatumGetPointer(value)));
 }
 
 /*
@@ -1691,7 +1691,7 @@ codegen_const_expression(codegen_context *context,
 			else if (con->constlen == -1)
 				appendBinaryStringInfo(buf,
 									   DatumGetPointer(con->constvalue),
-									   VARSIZE_ANY(con->constvalue));
+									   VARSIZE_ANY(DatumGetPointer(con->constvalue)));
 			else
 				elog(ERROR, "unsupported type length: %d", con->constlen);
 		}
@@ -2577,7 +2577,7 @@ try_casewhen_expression_by_hashed_array(codegen_context *context,
 				else
 					appendBinaryStringInfo(&temp,
 										   DatumGetPointer(e_con->constvalue),
-										   VARSIZE_ANY(e_con->constvalue));
+										   VARSIZE_ANY(DatumGetPointer(e_con->constvalue)));
 			}
 			/* result */
 			if (!r_con->constisnull)
@@ -2594,7 +2594,7 @@ try_casewhen_expression_by_hashed_array(codegen_context *context,
 				else
 					appendBinaryStringInfo(&temp,
 										   DatumGetPointer(r_con->constvalue),
-										   VARSIZE_ANY(r_con->constvalue));
+										   VARSIZE_ANY(DatumGetPointer(r_con->constvalue)));
 			}
 		}
 		/* default value, if any */
@@ -2612,7 +2612,7 @@ try_casewhen_expression_by_hashed_array(codegen_context *context,
 				else
 					offset = __appendBinaryStringInfo(&temp,
 													  DatumGetPointer(d_con->constvalue),
-													  VARSIZE_ANY(d_con->constvalue));
+													  VARSIZE_ANY(DatumGetPointer(d_con->constvalue)));
 			}
 			kexp->u.haop.default_offset = offset;
 		}
@@ -2859,7 +2859,7 @@ __build_hashed_array_op_expression(codegen_context *context,
 				if (dtype_e->type_byval)
 					appendBinaryStringInfo(&temp, &datum, dtype_e->type_length);
 				else
-					appendBinaryStringInfo(&temp, DatumGetPointer(datum), VARSIZE_ANY(datum));
+					appendBinaryStringInfo(&temp, DatumGetPointer(datum), VARSIZE_ANY(DatumGetPointer(datum)));
 			}
 			/* value (bool has character alignment) */
 			appendStringInfoChar(&temp, true);

--- a/src/executor.c
+++ b/src/executor.c
@@ -2173,11 +2173,11 @@ pgstromSharedStateInitDSM(CustomScanState *node,
 			ParallelTableScanDesc pdesc = (ParallelTableScanDesc) dsm_addr;
 
 			table_parallelscan_initialize(heap_rel, pdesc, estate->es_snapshot);
-			scan = table_beginscan_parallel(heap_rel, pdesc);
+			scan = table_beginscan_parallel(heap_rel, pdesc, SO_NONE);
 		}
 		else
 		{
-			scan = table_beginscan(heap_rel, estate->es_snapshot, 0, NULL);
+			scan = table_beginscan(heap_rel, estate->es_snapshot, 0, NULL, SO_NONE);
 		}
 		pts->css.ss.ss_currentScanDesc = scan;
 	}
@@ -2232,7 +2232,8 @@ pgstromSharedStateAttachDSM(CustomScanState *node,
 	if (heap_rel)
 	{
 		ParallelTableScanDesc pdesc = (ParallelTableScanDesc) dsm_addr;
-		pts->css.ss.ss_currentScanDesc = table_beginscan_parallel(heap_rel, pdesc);
+		pts->css.ss.ss_currentScanDesc = table_beginscan_parallel(heap_rel, pdesc,
+																	  SO_NONE);
 	}
 }
 

--- a/src/executor.c
+++ b/src/executor.c
@@ -737,8 +737,8 @@ pgstromBuildSessionInfo(pgstromTaskState *pts,
 
 		Assert((pp_info->xpu_task_flags & DEVTASK__SELECT_INTO_DIRECT) != 0);
 		session->select_into_pathname =
-			__appendBinaryStringInfo(&buf, VARDATA_ANY(pathname),
-									 VARSIZE_ANY_EXHDR(pathname));
+			__appendBinaryStringInfo(&buf, VARDATA_ANY(DatumGetPointer(pathname)),
+									 VARSIZE_ANY_EXHDR(DatumGetPointer(pathname)));
 		appendStringInfoChar(&buf, '\0');
 
 		/* length and block_offset must be set on allocation time */

--- a/src/gpu_cache.c
+++ b/src/gpu_cache.c
@@ -1200,7 +1200,7 @@ __gpuCacheInitialLoadMain(GpuCacheDesc *gc_desc, Relation rel)
 	TableScanDesc	hscan;
 	HeapTuple		tuple;
 
-	hscan = table_beginscan(rel, SnapshotAny, 0, NULL);
+	hscan = table_beginscan(rel, SnapshotAny, 0, NULL, SO_NONE);
 	while ((tuple = heap_getnext(hscan, ForwardScanDirection)) != NULL)
 	{
 		TransactionId	xmin, xmax;

--- a/src/gpu_join.c
+++ b/src/gpu_join.c
@@ -1641,6 +1641,34 @@ execInnerPreloadOneDepth(MemoryContext memcxt,
 /*
  * innerPreloadSetupGiSTIndex
  */
+typedef struct
+{
+	BlockNumber	blkno;
+	uint32			offno;
+} GistPageParent;
+
+StaticAssertDecl(sizeof(GistPageParent) == sizeof(PageXLogRecPtr),
+				 "GiST parent metadata must fit in pd_lsn");
+
+static inline GistPageParent
+GistPageGetParent(PageHeader hpage)
+{
+	GistPageParent	parent;
+
+	memcpy(&parent, &hpage->pd_lsn, sizeof(parent));
+	return parent;
+}
+
+static inline void
+GistPageSetParent(PageHeader hpage,
+				  BlockNumber parent_blkno,
+				  OffsetNumber parent_offno)
+{
+	GistPageParent	parent = {parent_blkno, parent_offno};
+
+	memcpy(&hpage->pd_lsn, &parent, sizeof(parent));
+}
+
 static void
 __innerPreloadSetupGiSTIndexWalker(Relation i_rel,
 								   char *base,
@@ -1653,12 +1681,14 @@ __innerPreloadSetupGiSTIndexWalker(Relation i_rel,
 	{
 		Page			page = (Page)(base + BLCKSZ * blkno);
 		PageHeader		hpage = (PageHeader) page;
+#ifdef USE_ASSERT_CHECKING
+		GistPageParent parent = GistPageGetParent(hpage);
+#endif
 		OffsetNumber	i, maxoff;
 
-		Assert(hpage->pd_lsn.xlogid == InvalidBlockNumber &&
-			   hpage->pd_lsn.xrecoff == InvalidOffsetNumber);
-		hpage->pd_lsn.xlogid = parent_blkno;
-		hpage->pd_lsn.xrecoff = parent_offno;
+		Assert(parent.blkno == InvalidBlockNumber &&
+			   parent.offno == InvalidOffsetNumber);
+		GistPageSetParent(hpage, parent_blkno, parent_offno);
 		if (!GistPageIsLeaf(page))
 		{
 			maxoff = PageGetMaxOffsetNumber(page);
@@ -1930,8 +1960,9 @@ again:
 					hpage = KDS_BLOCK_PGPAGE(kds, k);
 
 					memcpy(hpage, page, BLCKSZ);
-					hpage->pd_lsn.xlogid = InvalidBlockNumber;
-					hpage->pd_lsn.xrecoff = InvalidOffsetNumber;
+					GistPageSetParent(hpage,
+									  InvalidBlockNumber,
+									  InvalidOffsetNumber);
 					KDS_BLOCK_BLCKNR(kds, k) = k;
 
 					UnlockReleaseBuffer(buffer);

--- a/src/main.c
+++ b/src/main.c
@@ -613,7 +613,11 @@ static PlannedStmt *
 pgstrom_post_planner(Query *parse,
 					 const char *query_string,
 					 int cursorOptions,
-					 ParamListInfo boundParams)
+					 ParamListInfo boundParams
+#if PG_VERSION_NUM >= 190000
+					 , ExplainState *es
+#endif
+	)
 {
 	HTAB	   *saved_ppinfo_htable = pgstrom_ppinfo_htable;
 	PlannedStmt *pstmt;
@@ -626,7 +630,11 @@ pgstrom_post_planner(Query *parse,
 		pstmt = planner_hook_next(parse,
 								  query_string,
 								  cursorOptions,
-								  boundParams);
+								  boundParams
+#if PG_VERSION_NUM >= 190000
+								  , es
+#endif
+								  );
 		/* remove dummy plan & push-down Result + GpuPreAgg */
 		pgstrom_removal_dummy_plans(pstmt, &pstmt->planTree);
 		foreach (lc, pstmt->subplans)

--- a/src/misc.c
+++ b/src/misc.c
@@ -1008,6 +1008,7 @@ pgstrom_copy_pathnode(const Path *pathnode)
 				b->subpath = pgstrom_copy_pathnode(a->subpath);
 				return &b->path;
 			}
+#if PG_VERSION_NUM < 190000
 		case T_UpperUniquePath:
 			{
 				UpperUniquePath *a = (UpperUniquePath *)pathnode;
@@ -1015,6 +1016,7 @@ pgstrom_copy_pathnode(const Path *pathnode)
 				b->subpath = pgstrom_copy_pathnode(a->subpath);
 				return &b->path;
 			}
+#endif
 		case T_AggPath:
 			{
 				AggPath		   *a = (AggPath *)pathnode;

--- a/src/pg_compat.h
+++ b/src/pg_compat.h
@@ -130,6 +130,15 @@ typedef Node *(*tree_mutator_callback) (Node *node, void *context);
 #endif
 
 /*
+ * MEMO: PostgreSQL v19 adds user-specified ScanOptions to table_beginscan()
+ * and table_beginscan_parallel().
+ */
+#if PG_VERSION_NUM < 190000
+#define table_beginscan(a,b,c,d,e)			table_beginscan((a),(b),(c),(d))
+#define table_beginscan_parallel(a,b,c)		table_beginscan_parallel((a),(b))
+#endif
+
+/*
  * MEMO: PostgreSQL v18 removed lc_collate_is_c() that is a checker function
  * to determine the collation is simple enough.
  *

--- a/src/pg_compat.h
+++ b/src/pg_compat.h
@@ -157,6 +157,19 @@ pgstrom_heap_page_prune_opt(Relation relation, Buffer buffer)
 }
 
 /*
+ * MEMO: PostgreSQL v19 widened BufferDesc.state and its BM_* flags to 64bit.
+ */
+static inline uint64
+pgstrom_buffer_state(BufferDesc *buf_desc)
+{
+#if PG_VERSION_NUM < 190000
+	return pg_atomic_read_u32(&buf_desc->state);
+#else
+	return pg_atomic_read_u64(&buf_desc->state);
+#endif
+}
+
+/*
  * MEMO: PostgreSQL v18 removed lc_collate_is_c() that is a checker function
  * to determine the collation is simple enough.
  *

--- a/src/pg_compat.h
+++ b/src/pg_compat.h
@@ -139,6 +139,24 @@ typedef Node *(*tree_mutator_callback) (Node *node, void *context);
 #endif
 
 /*
+ * MEMO: PostgreSQL v19 adds a reusable visibility-map buffer and a read-only
+ * hint to heap_page_prune_opt().
+ */
+static inline void
+pgstrom_heap_page_prune_opt(Relation relation, Buffer buffer)
+{
+#if PG_VERSION_NUM < 190000
+	heap_page_prune_opt(relation, buffer);
+#else
+	Buffer		vmbuffer = InvalidBuffer;
+
+	heap_page_prune_opt(relation, buffer, &vmbuffer, false);
+	if (BufferIsValid(vmbuffer))
+		ReleaseBuffer(vmbuffer);
+#endif
+}
+
+/*
  * MEMO: PostgreSQL v18 removed lc_collate_is_c() that is a checker function
  * to determine the collation is simple enough.
  *

--- a/src/pg_compat.h
+++ b/src/pg_compat.h
@@ -170,6 +170,22 @@ pgstrom_buffer_state(BufferDesc *buf_desc)
 }
 
 /*
+ * MEMO: PostgreSQL v19 makes LWLockNewTrancheId() register the tranche name.
+ */
+static inline int
+pgstrom_new_lwlock_tranche(const char *tranche_name)
+{
+#if PG_VERSION_NUM < 190000
+	int			tranche_id = LWLockNewTrancheId();
+
+	LWLockRegisterTranche(tranche_id, tranche_name);
+	return tranche_id;
+#else
+	return LWLockNewTrancheId(tranche_name);
+#endif
+}
+
+/*
  * MEMO: PostgreSQL v18 removed lc_collate_is_c() that is a checker function
  * to determine the collation is simple enough.
  *

--- a/src/pg_strom.h
+++ b/src/pg_strom.h
@@ -69,6 +69,7 @@
 #include "common/hashfn.h"
 #include "common/int.h"
 #include "common/md5.h"
+#include "executor/instrument.h"
 #include "executor/nodeIndexscan.h"
 #include "executor/nodeSubplan.h"
 #include "foreign/fdwapi.h"

--- a/src/relscan.c
+++ b/src/relscan.c
@@ -442,7 +442,7 @@ __relScanDirectCachedBlock(pgstromTaskState *pts,
 								RBM_NORMAL,
 								hscan_strategy);
 	/* prune the old items, if any */
-	heap_page_prune_opt(relation, buffer);
+	pgstrom_heap_page_prune_opt(relation, buffer);
 	/* let's check tuples visibility for each */
 	LockBuffer(buffer, BUFFER_LOCK_SHARE);
 	spage = (Page) BufferGetPage(buffer);

--- a/src/relscan.c
+++ b/src/relscan.c
@@ -523,7 +523,7 @@ __relScanDirectCheckBufferClean(SMgrRelation smgr, BlockNumber block_num)
 	LWLock	   *bufLock;
 	Buffer		buffer;
 	BufferDesc *bufDesc;
-	uint32_t	bufState;
+	uint64		bufState;
 
 	smgr_init_buffer_tag(&bufTag, smgr, MAIN_FORKNUM, block_num);
 	bufHash = BufTableHashCode(&bufTag);
@@ -538,7 +538,7 @@ __relScanDirectCheckBufferClean(SMgrRelation smgr, BlockNumber block_num)
 		return true;		/* OK, block is not buffered */
 	}
 	bufDesc = GetBufferDescriptor(buffer);
-	bufState = pg_atomic_read_u32(&bufDesc->state);
+	bufState = pgstrom_buffer_state(bufDesc);
 	LWLockRelease(bufLock);
 
 	return (bufState & BM_DIRTY) == 0;

--- a/src/tinyint.c
+++ b/src/tinyint.c
@@ -13,7 +13,7 @@
 
 #define DatumGetInt8(x)			((int8) (x))
 #define PG_GETARG_INT8(x)		DatumGetInt8(PG_GETARG_DATUM(x))
-#define PG_RETURN_INT8(x)		return Int8GetDatum(x)
+#define PG_RETURN_INT8(x)		return ((Datum)(int8)(x))
 
 /*
  * Type input / output functions


### PR DESCRIPTION
## 概要

PG-StromをPostgreSQL 19でビルドできるよう、PostgreSQL内部APIおよびデータ構造の変更に追従しました。

PostgreSQL 17および18との互換性も維持しています。

## 主な変更

- planner hookに追加された`ExplainState`引数へ対応
- table scan APIのオプション引数追加へ対応
- executor instrumentationヘッダを明示的に追加
- GiSTページに格納する親情報をバージョン別に抽象化
- heap page prune APIの追加引数へ対応
- `BufferDesc.state`の64bit化へ対応
- `ALIGNOF_LONG`の廃止に伴い`MAXIMUM_ALIGNOF`へ移行
- 配列null bitmapの型を`bits8`から`uint8`へ変更
- LWLock tranche名登録APIの変更へ対応
- `UpperUniquePath`の統合へ対応
- `Int8GetDatum()`の廃止に伴い、tinyintのDatum変換を既存表現と互換な実装へ変更

## 更新ファイル

- `src/arrow_fdw.c`
- `src/executor.c`
- `src/gpu_cache.c`
- `src/gpu_join.c`
- `src/main.c`
- `src/misc.c`
- `src/pg_compat.h`
- `src/pg_strom.h`
- `src/relscan.c`
- `src/tinyint.c`

## ビルド検証

以下のバージョンで拡張全体を強制再ビルドし、全オブジェクトのコンパイルおよび`pg_strom.so`のリンク成功を確認しました。

- PostgreSQL 17.9
- PostgreSQL 18.3
- PostgreSQL 19 beta 2

また、各バージョンでPG-StromのロードとGPU実行を確認しています。

## リグレッションテスト

### PostgreSQL 17.9

- 全23件中22件成功
- `pgstrom_init`のみ差分あり
- `pgstrom_init`の差分は、回帰テスト用データセットの初期化時に発生する仕様上許容されるもの
- その他のデグレードなし

### PostgreSQL 18.3

- 全23件中22件成功
- `pgstrom_init`のみ仕様上の差分あり
- その他のデグレードなし

### PostgreSQL 19 beta 2

PG18の期待値を使用した暫定比較では、以下の差分を確認しています。

- `dtype_time`
- `arrow_cpu`
- `arrow_index`
- `misc`

このうち`arrow_index`には、PG19で`InitPlan 1`が`InitPlan expr_1`へ変わったEXPLAIN表示差分が含まれます。

PG19向け期待値セットはまだリポジトリに存在しないため、これらのリグレッションテスト差分の調査・対応は後続作業とします。本PRはPG19でのビルド互換性対応を対象としています。

## 補足

- 各ビルドエラーは独立したコミットで修正
- 各修正後にPostgreSQL 17、18、19でビルド検証を実施
- コミット本文に変更理由、互換性上の考慮点、検証内容を記載