### PR TITLE
PostgreSQL 19でdateからtimestamptzへのGPUキャスト結果がCPUと一致しない問題を修正

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -8,6 +8,9 @@ GITHASH_IF_NOT_GIVEN := HEAD
 #
 PG_MAJORVERSION := $(shell $(PG_CONFIG) --version | sed 's/\./ /g' | awk '{print $$2}')
 PG_MINORVERSION := $(shell $(PG_CONFIG) --version | sed 's/\./ /g' | awk '{print $$3}')
+PG_INCLUDEDIR_SERVER := $(shell $(PG_CONFIG) --includedir-server)
+PG_VERSION_NUM := $(shell awk '/^#define PG_VERSION_NUM / { print $$3 }' \
+				$(PG_INCLUDEDIR_SERVER)/pg_config.h)
 
 #
 # PG-Strom version signature

--- a/src/Makefile.cuda
+++ b/src/Makefile.cuda
@@ -37,6 +37,7 @@ endif
 
 # flags to build GPU libraries
 __NVCC_CFLAGS += -I $(shell $(PG_CONFIG) --includedir-server) \
+                 -DPG_VERSION_NUM=$(PG_VERSION_NUM)      \
                  --maxrregcount=$(MAXREGCOUNT)           \
                  --source-in-ptx -lineinfo               \
                  -DHAVE_FLOAT2                           \

--- a/src/gpu_service.c
+++ b/src/gpu_service.c
@@ -844,6 +844,7 @@ __rebuild_gpu_fatbin_file(const char *fatbin_dir,
 						 " --maxrregcount=%d"
 						 " --source-in-ptx -lineinfo"
 						 " -I. -I%s "
+						 " -DPG_VERSION_NUM=%d "
 						 " -DHAVE_FLOAT2 "
 						 " -DCUDA_MAXTHREADS_PER_BLOCK=%u "
 #ifdef WITH_POSTGIS
@@ -856,6 +857,7 @@ __rebuild_gpu_fatbin_file(const char *fatbin_dir,
 						 pgstrom_cuda_toolkit_basedir,
 						 CUDA_MAXREGCOUNT,
 						 PGINCLUDEDIR,
+						 PG_VERSION_NUM,
 						 CUDA_MAXTHREADS_PER_BLOCK,
 						 tok,
 						 PGSHAREDIR, tok, tok);

--- a/src/xpu_timelib.h
+++ b/src/xpu_timelib.h
@@ -151,9 +151,19 @@ xpu_date_arrow_datum_store(kern_context *kcxt,
 #define TZ_STRLEN_MAX	255
 #endif
 
+/*
+ * PostgreSQL v19 changed ttinfo.tt_utoff from int32 to int_fast32_t.
+ * It is an 8-byte integer on the supported 64-bit platforms.
+ */
+#if PG_VERSION_NUM >= 190000
+typedef int64_t		pg_tz_utoff_t;
+#else
+typedef int32_t		pg_tz_utoff_t;
+#endif
+
 struct pg_tz_ttinfo
 {								/* time type information */
-	int32_t		tt_utoff;		/* UT offset in seconds */
+	pg_tz_utoff_t tt_utoff;		/* UT offset in seconds */
 	bool		tt_isdst;		/* used to set tm_isdst */
 	int32_t		tt_desigidx;	/* abbreviation list index */
 	bool		tt_ttisstd;		/* transition is std time */


### PR DESCRIPTION
## 概要

PostgreSQL 19で、`date` から `timestamptz` へのGPUキャスト結果がCPU実行結果と一致しない問題を修正します。

Closes #1051

## 原因

PostgreSQL 19では、タイムゾーン情報を保持する内部構造体の `ttinfo.tt_utoff` が `int32` から `int_fast32_t` に変更されました。

64bit環境ではフィールドサイズと後続フィールドのオフセットが変わりますが、PG-Strom側では従来の構造体レイアウトを使用していたため、GPUへ転送したタイムゾーン情報を正しく参照できていなかったと思われます。

## 変更内容

- PostgreSQL 19以降では `tt_utoff` に64bit型を使用する
- `pg_config.h` から `PG_VERSION_NUM` を取得する
- 通常のCUDAビルドへ `PG_VERSION_NUM` を渡す
- 起動時のオンデマンドfatbin再構築にも `PG_VERSION_NUM` を渡す

## テスト

PostgreSQL 16、17、18、19でビルドとリグレッションテストを実行しました。

| PostgreSQL | ビルド | dtype_time | arrow_cpu |
|---|---:|---:|---:|
| 16 | PASS | PASS | PASS |
| 17 | PASS | PASS | PASS |
| 18 | PASS | PASS | PASS |
| 19 | PASS | PASS | PASS |
