### PR TITLE
PostgreSQL 19でEager Aggregationの出力をGpuJoinへ渡すとエラーになる問題を修正

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1402,11 +1402,35 @@ equalVar(const void *__a, const void *__b)
 }
 
 /*
- * lookup_input_varnode_defitem
+ * equalInputExpr - compares expressions supplied by an input PathTarget
+ *
+ * Aggref identifiers are assigned while the plan is being built, so the
+ * same partial aggregate can have different identifiers in a PathTarget
+ * and in the upper plan node which references it.
+ */
+static bool
+equalInputExpr(const Expr *a, const Expr *b)
+{
+	if (IsA(a, Var) && IsA(b, Var))
+		return equalVar(a, b);
+	if (IsA(a, Aggref) && IsA(b, Aggref))
+	{
+		Aggref *aa = copyObject((Aggref *)a);
+		Aggref *bb = copyObject((Aggref *)b);
+
+		aa->aggno = bb->aggno = -1;
+		aa->aggtransno = bb->aggtransno = -1;
+		return equal(aa, bb);
+	}
+	return equal(a, b);
+}
+
+/*
+ * lookup_input_expression_defitem
  */
 static codegen_kvar_defitem *
-lookup_input_varnode_defitem(codegen_context *context,
-							 Var *var,
+lookup_input_expression_defitem(codegen_context *context,
+							 Expr *expr,
 							 int curr_depth,
 							 bool allows_host_only_types)
 {
@@ -1421,16 +1445,17 @@ lookup_input_varnode_defitem(codegen_context *context,
 	int32_t		kv_xdatum_sizeof;
 	int32_t		kv_kvec_sizeof;
 
-	if (!IsA(var, Var))
-		return NULL;
-
-	if (var->varno == context->base_relid)
+	if (IsA(expr, Var) && ((Var *)expr)->varno == context->base_relid)
 	{
+		Var *var = (Var *)expr;
+
 		depth = 0;
 		resno = var->varattno;
 		Assert(resno != InvalidAttrNumber);
 		goto found;
 	}
+	if (!IsA(expr, Var) && !IsA(expr, Aggref))
+		return NULL;
 
 	for (depth = 1; depth <= context->num_inner_rels; depth++)
 	{
@@ -1439,7 +1464,8 @@ lookup_input_varnode_defitem(codegen_context *context,
 		resno = 1;
 		foreach (lc, target->exprs)
 		{
-			if (equalVar(var, lfirst(lc)))
+			Expr *input_expr = lfirst(lc);
+			if (equalInputExpr(expr, input_expr))
 				goto found;
 			resno++;
 		}
@@ -1453,14 +1479,14 @@ found:
 		if (kvdef->kv_depth == depth &&
 			kvdef->kv_resno == resno)
 		{
-			Assert(equalVar(var, kvdef->kv_expr));
+			Assert(equalInputExpr(expr, kvdef->kv_expr));
 			kvdef->kv_maxref = Max(kvdef->kv_maxref, curr_depth);
 			return kvdef;
 		}
 	}
 
 	/* attach new one */
-	kv_type_oid = exprType((Node *)var);
+	kv_type_oid = exprType((Node *)expr);
 	if (!__assign_codegen_kvar_defitem_type_params(kv_type_oid,
 												   &kv_type_code,
 												   &kv_type_byval,
@@ -1485,7 +1511,7 @@ found:
 	kvdef->kv_typlen      = kv_type_length;
 	kvdef->kv_xdatum_sizeof = kv_xdatum_sizeof;
 	kvdef->kv_kvec_sizeof = kv_kvec_sizeof;
-	kvdef->kv_expr        = (Expr *)var;
+	kvdef->kv_expr        = expr;
 	__assign_codegen_kvar_defitem_subfields(kvdef);
 	context->kvecs_usage += KVEC_ALIGN(kvdef->kv_kvec_sizeof);
 	context->kvars_deflist = lappend(context->kvars_deflist, kvdef);
@@ -1507,16 +1533,20 @@ __try_inject_temporary_expression(codegen_context *context,
 	kern_expression kexp;
 	ListCell   *lc;
 	int			pos = -1;
+	bool		is_input = false;
 
 	/*
-	 * When 'expr' is simple Var-reference on the input relations,
-	 * we don't need to inject expression node here.
+	 * When 'expr' is already computed by an input relation, we don't
+	 * need to inject an expression node here.
 	 */
-	kvdef = lookup_input_varnode_defitem(context, (Var *)expr,
+	kvdef = lookup_input_expression_defitem(context, expr,
 										 curr_depth,
 										 allows_host_only_types);
 	if (kvdef)
+	{
+		is_input = true;
 		goto found;
+	}
 
 	/*
 	 * Try to find out the expression which already injected to the
@@ -1571,7 +1601,29 @@ found:
 	kexp.u.save.sv_slot_id   = kvdef->kv_slot_id;
 	if (buf)
 		pos = __appendBinaryStringInfo(buf, &kexp, kexp.args_offset);
-	if (codegen_expression_walker(context, buf, curr_depth, expr) < 0)
+	if (is_input)
+	{
+		if (buf)
+		{
+			kern_expression kvar;
+			int			kvar_pos;
+
+			memset(&kvar, 0, sizeof(kvar));
+			kvar.exptype = kvdef->kv_type_code;
+			kvar.expflags = context->kexp_flags;
+			kvar.opcode = FuncOpCode__VarExpr;
+			kvar.u.v.var_slot_id = kvdef->kv_slot_id;
+			if ((context->xpu_task_flags & DEVKIND__NVIDIA_GPU) != 0 &&
+				kvdef->kv_offset >= 0 &&
+				kvdef->kv_depth != curr_depth)
+				kvar.u.v.var_offset = kvdef->kv_offset;
+			else
+				kvar.u.v.var_offset = -1;
+			kvar_pos = __appendBinaryStringInfo(buf, &kvar, SizeOfKernExprVar);
+			__appendKernExpMagicAndLength(buf, kvar_pos);
+		}
+	}
+	else if (codegen_expression_walker(context, buf, curr_depth, expr) < 0)
 		return NULL;
 	if (buf)
 		__appendKernExpMagicAndLength(buf, pos);
@@ -1798,8 +1850,8 @@ codegen_var_expression(codegen_context *context,
 {
 	codegen_kvar_defitem *kvdef;
 
-	kvdef = lookup_input_varnode_defitem(context,
-										 var,
+	kvdef = lookup_input_expression_defitem(context,
+										 (Expr *)var,
 										 curr_depth,
 										 false);
 	if (buf)

--- a/src/gpu_join.c
+++ b/src/gpu_join.c
@@ -1037,6 +1037,21 @@ GpuJoinAddCustomPath(PlannerInfo *root,
 /*
  * pgstrom_build_tlist_dev
  */
+static bool
+__pgstrom_equal_input_expression(Node *a, Node *b)
+{
+	if (IsA(a, Aggref) && IsA(b, Aggref))
+	{
+		Aggref *aa = copyObject((Aggref *)a);
+		Aggref *bb = copyObject((Aggref *)b);
+
+		aa->aggno = bb->aggno = -1;
+		aa->aggtransno = bb->aggtransno = -1;
+		return equal(aa, bb);
+	}
+	return equal(a, b);
+}
+
 static List *
 __pgstrom_build_tlist_dev_expr(List *tlist_dev,
 							   Node *node,
@@ -1071,10 +1086,11 @@ __pgstrom_build_tlist_dev_expr(List *tlist_dev,
 		resno = 1;
 		foreach (lc2, reltarget->exprs)
 		{
-			if (equal(node, lfirst(lc2)))
+			if (__pgstrom_equal_input_expression(node, lfirst(lc2)))
 				goto found;
 			resno++;
 		}
+		depth++;
 	}
 	depth = -1;
 	resno = -1;
@@ -1086,6 +1102,7 @@ found:
 	 * All the GPU kernel doing is simple copy.
 	 */
 	if (IsA(node, Var) ||
+		(depth > 0 && IsA(node, Aggref)) ||
 		pgstrom_xpu_expression((Expr *)node,
 							   xpu_task_flags,
 							   base_relid,
@@ -1117,6 +1134,35 @@ found:
 	return tlist_dev;
 }
 
+/*
+ * __pgstrom_is_inner_path_target
+ *
+ * True if the expression is already computed by one of the inner paths.
+ * Such an expression only needs to be copied by the device projection,
+ * regardless of whether the expression itself is executable on the device.
+ */
+static bool
+__pgstrom_is_inner_path_target(Node *node, List *inner_target_list)
+{
+	ListCell   *lc1;
+
+	if (!IsA(node, Aggref))
+		return false;
+
+	foreach (lc1, inner_target_list)
+	{
+		PathTarget *reltarget = lfirst(lc1);
+		ListCell   *lc2;
+
+		foreach (lc2, reltarget->exprs)
+		{
+			if (__pgstrom_equal_input_expression(node, lfirst(lc2)))
+				return true;
+		}
+	}
+	return false;
+}
+
 static void
 pgstrom_build_join_tlist_dev(codegen_context *context,
 							 PlannerInfo *root,
@@ -1141,7 +1187,9 @@ pgstrom_build_join_tlist_dev(codegen_context *context,
 			TargetEntry *tle = lfirst(lc);
 
 			context->top_expr = tle->expr;
-			if (contain_var_clause((Node *)tle->expr))
+			if (contain_var_clause((Node *)tle->expr) ||
+				__pgstrom_is_inner_path_target((Node *)tle->expr,
+										   inner_target_list))
 				tlist_dev = __pgstrom_build_tlist_dev_expr(tlist_dev,
 														   (Node *)tle->expr,
 														   context->xpu_task_flags,
@@ -1167,7 +1215,8 @@ pgstrom_build_join_tlist_dev(codegen_context *context,
 			Node   *node = lfirst(lc);
 
 			context->top_expr = (Expr *)node;
-			if (contain_var_clause(node))
+			if (contain_var_clause(node) ||
+				__pgstrom_is_inner_path_target(node, inner_target_list))
 				tlist_dev = __pgstrom_build_tlist_dev_expr(tlist_dev,
 														   node,
 														   context->xpu_task_flags,


### PR DESCRIPTION
## 概要

PostgreSQL 19で、Eager Aggregationの出力がGpuJoinの入力式となった場合にエラーが発生する問題を修正します。

Closes #1052

## 変更内容

- 入力パスで部分集約された式を、GpuJoinのデバイス用ターゲットリストへ追加します。
- これらの集約式をGPU上で再評価せず、入力パスで計算済みの値として参照します。
- プラン構築中に異なる値が割り当てられる場合がある `aggno` と `aggtransno` に依存せず、同一の `Aggref` を判定します。
- 通常の式および `Var` に対する既存の処理は維持します。

## テスト

- PostgreSQL 16、17、18、19でビルドできることを確認しました。
- PostgreSQL 19でGpuJoinを有効にした状態の `misc` リグレッションテストが成功することを確認しました。
- Issue #1052のクエリで `Aggref found in non-Agg plan node` が発生しないことを確認しました。
